### PR TITLE
Use ubuntu base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 COPY build/linux-amd64/bin/surveysvc /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM alpine:3.6
-MAINTAINER John Topley "john.topley@ons.gov.uk"
-RUN apk update && apk upgrade
+FROM ubuntu:latest
+
 COPY build/linux-amd64/bin/surveysvc /usr/local/bin/
+
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/surveysvc"]
+
+ENTRYPOINT [ "/usr/local/bin/surveysvc" ]


### PR DESCRIPTION
When the binary is surveysvc binary is built on travis and a docker
image based on alpine is used starting the surveysvc container fails to
start. The error suggests the binary is invalid.

```
standard_init_linux.go:185: exec user process caused "no such file or
directory".
```

 If the same process is followed on a osx by running `make` and
`docker build . -t sdcplatform/surveysvc` the docker container will run
with the alpine docker base image.

When changing the docker base image to ubuntu it fixes the problem. This
is a path of least resistance fix. This impact is that the image is
slightly bigger but as we are only using it for local development it
shouldn't matter.