### PR TITLE
Add logging for failing to create API

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	api, err := models.NewAPI(db)
 	if err != nil {
-		log.Fatal(`event="Failed to start" error="unable to initialise API model"`)
+		logger.Fatal(fmt.Sprintf(`event="Failed to start" error="unable to initialise API model" error_message=%s`, err.Error()))
 	}
 
 	// Webserver - strictslash set to true to match trailing slashes to routes


### PR DESCRIPTION
Add extra logging to understand why api creation failed. Logging goes from

```
survey                | {"level":"info","ts":1513948908.231153,"caller":"models/db.go:95","msg":"Database schema exists","service":"surveysvc","event":"database bootstrap","created":"2017-12-22T13:21:48Z"}
survey                | 2017/12/22 13:21:48 event="Failed to start" error="unable to initialise API model"
```
to
```
survey                | {"level":"info","ts":1513950485.2575111,"caller":"models/db.go:95","msg":"Database schema exists","service":"surveysvc","event":"database bootstrap","created":"2017-12-22T13:48:05Z"}
survey                | {"level":"fatal","ts":1513950485.2588587,"caller":"rm-survey-service/main.go:44","msg":"event=\"Failed to start\" error=\"unable to initialise API model\" error_message=pq: column \"legalbasis\" does not exist","stacktrace":"main.main\n\t/Users/benjefferies/source/go/src/github.com/ONSdigital/rm-survey-service/main.go:44\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:185"}
```