### PR TITLE
Add curl for healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt update && apt install curl -y
+RUN apt-get update && apt-get install curl -y
 EXPOSE 8080
 
 COPY build/linux-amd64/bin/main /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install curl -y
+RUN apt-get update\
+     && apt-get install curl=7.58.0-2ubuntu1 -y --no-install-recommends\
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
 EXPOSE 8080
 
 COPY build/linux-amd64/bin/main /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:18.04
 
-COPY build/linux-amd64/bin/main /usr/local/bin/
-
+RUN apt update && apt install curl -y
 EXPOSE 8080
+
+COPY build/linux-amd64/bin/main /usr/local/bin/
 
 ENTRYPOINT [ "/usr/local/bin/main" ]


### PR DESCRIPTION
The healthchecks added in
https://github.com/ONSdigital/ras-rm-docker-dev/pull/25 will use curl to
test the info end point to see if the service is healthy and running. It
depends on curl or something which can ping the endpoint being installed
in the container to do this check.