### PR TITLE
Move setting migration source for cloud foundry

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,6 +115,10 @@ func configureEnvironment() (dataSource, port string, migrationSource string) {
 	dataSource = "postgres://postgres:password@localhost/postgres?sslmode=disable"
 	port = "8080"
 	migrationSource = "file:///db-migrations"
+    if v := os.Getenv("MIGRATION_SOURCE"); len(v) > 0 {
+        migrationSource = v
+    }
+
 	appEnv, err := cfenv.Current()
 
 	if err != nil {
@@ -126,10 +130,6 @@ func configureEnvironment() (dataSource, port string, migrationSource string) {
 
 		if v := os.Getenv("DATABASE_URL"); len(v) > 0 {
 			dataSource = v
-		}
-
-		if v := os.Getenv("MIGRATION_SOURCE"); len(v) > 0 {
-			migrationSource = v
 		}
 
 		return dataSource, port, migrationSource


### PR DESCRIPTION
This allows the service to be deployed in Cloud Foundry by setting the migration source.