### PR TITLE
Make db pool size configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Service version.
-VERSION = 10.47.2
+VERSION = 10.47.3
 
 # Cross-compilation values.
 ARCH=amd64

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Service version.
-VERSION = 10.47.3
+VERSION = 10.47.4
 
 # Cross-compilation values.
 ARCH=amd64

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The following environment variables may be overridden:
 | PORT                   | HTTP listener port                           | :8080                                                           |
 | security_user_name     | HTTP basic authentication user name          | N/A                                                             |
 | security_user_password | HTTP basic authentication password           | N/A                                                             |
+| CONN_MAX_LIFETIME      | Max lifetime of connection in pool in seconds| 0, so there is no time limit                                    |
+| MAX_IDLE_CONN          | Max idle connections to have in pool         | 2                                                               |
 
 ### Docker Image and PostgreSQL
 To start Docker containers for both PostgreSQL and the Survey service, run:

--- a/models/db_test.go
+++ b/models/db_test.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDBConnectionTested(t *testing.T) {
+	Convey("db connection tested before returned", t, func() {
+		db, _, err := sqlmock.New()
+		defer db.Close()
+
+		err = testDBConnection(db)
+
+		So(err, ShouldBeNil)
+	})
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The db connection pool needs to be configurable for performance tweaking. 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
1) Spin up the survey service with default settings
2) Hit the service with multiple requests (I used a Jmeter script with 100 users)
3) Watch your db connections go up (I used pgadmin to monitor open connections)
4) Stop the requests to the service and the db connections should go back to approx where they started.
5) Set environment var MAX_IDLE_CONN=50 and re run survey service
6) Repeat steps 2, 3 and 4 but instead of the connections going back to where they started you will see more idle connections than you started with.


# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/SwXkyTRo/44-optimise-db-connection-settings
