### PR TITLE
Use Postgres 9.6 in Docker as some SQL used is dependent on it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 database:
   container_name: postgres
-  image: k0st/alpine-postgres
+  image: postgres:9.6-alpine
   ports:
    - "5432:5432"
   environment:


### PR DESCRIPTION
# Motivation and Context
Fixes broken local setup

# What has changed
Uses an official Postgres 9.6 image

# How to test?
- Run `docker-compose up -d`
- Check that both postgres and the survey service are running
- Check list of surveys works - http://localhost:8080/surveys

# Links
Fixes #43 