### PR TITLE
Add .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 58%
+        threshold: null
+        base: auto
+    patch:
+      default: on


### PR DESCRIPTION
# Motivation and Context
Sets an achievable code coverage target so it's obvious when new code doesn't at least meet the current coverage. Currently all code coverage checks fail as the target is 100%.

# What has changed
Adds codecov configuration that sets a coverage target that passes and forces new changes to at least meet that target.

# How to test?
Check the codecov status on this pr

# Links
Fixes #45 