### PR TITLE
add the MIGRATION_SOURCE env var to the manifest

### DIFF
--- a/manifest-template.yml
+++ b/manifest-template.yml
@@ -12,5 +12,6 @@ applications:
     GOPACKAGENAME: github.com/ONSdigital/rm-survey-service
     security_user_name: REPLACE_BA_USERNAME
     security_user_password: REPLACE_BA_PASSWORD
+    MIGRATION_SOURCE: REPLACE_MIGRATION_SOURCE
   services:
     - DATABASE


### PR DESCRIPTION
# Motivation and Context
We need to add a placeholder to the manifest file so we can set the migration_source location for db-migration

# What has changed
MIGRATION_SOURCE placeholder added to the manifest template