### PR TITLE
Add create survey classifier endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.dll
 *.so
 *.dylib
+*.floo
+*.flooignore
 surveysvc
 
 # Build directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install: true
 go_import_path: github.com/ONSdigital/rm-survey-service
 
 script:
-  - make build test docker
+  - make build integration-test
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/API.md
+++ b/API.md
@@ -119,26 +119,18 @@ An `HTTP 404 Not Found` status code is returned if the survey or classifier type
 ## Post Survey Classifiers
 * `POST /surveys/<survey_id>/classifiers`
 
-The payload should be a list of classifiers, with a classifier type selector name and a list of classifier types as strings.
+The payload should be a classifier object, with a classifier type selector `name` and a list of `classifierTypes` as strings.
 
 ### Example JSON payload
 ```json
-[
-  {
+
+{
     "name": "COLLECTION_INSTRUMENT",
     "classifierTypes": [
       "FORM_TYPE",
       "LEGAL_BASIS"
     ]
-  },
-  {
-    "name": "COMMUNICATION_TEMPLATE",
-    "classifierTypes": [
-      "FORM_TYPE",
-      "LEGAL_BASIS"
-    ]
-  }
-]
+}
 ```
 
 An `HTTP 404 Not Found` status code is returned if the survey with the specified ID could not be found.

--- a/API.md
+++ b/API.md
@@ -115,3 +115,28 @@ An `HTTP 404 Not Found` status code is returned if the survey with the specified
 ```
 
 An `HTTP 404 Not Found` status code is returned if the survey or classifier type selector with the specified ID could not be found.
+
+## Post Survey Classifiers
+* `POST /surveys/<survey_id>/classifiers`
+
+### Example JSON payload
+```json
+[
+  {
+    "name": "COLLECTION_INSTRUMENT",
+    "classifierTypes": [
+      "FORM_TYPE",
+      "LEGAL_BASIS"
+    ]
+  },
+  {
+    "name": "COMMUNICATION_TEMPLATE",
+    "classifierTypes": [
+      "FORM_TYPE",
+      "LEGAL_BASIS"
+    ]
+  }
+]
+```
+
+An `HTTP 404 Not Found` status code is returned if the survey with the specified ID could not be found.

--- a/API.md
+++ b/API.md
@@ -119,6 +119,8 @@ An `HTTP 404 Not Found` status code is returned if the survey or classifier type
 ## Post Survey Classifiers
 * `POST /surveys/<survey_id>/classifiers`
 
+The payload should be a list of classifiers, with a classifier type selector name and a list of classifier types as strings.
+
 ### Example JSON payload
 ```json
 [
@@ -140,3 +142,5 @@ An `HTTP 404 Not Found` status code is returned if the survey or classifier type
 ```
 
 An `HTTP 404 Not Found` status code is returned if the survey with the specified ID could not be found.
+
+An `HTTP 409 Conflict` status code is returned if a classifier type selector already exists for any of the names in the payload.

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,16 @@ build: clean
 test:
 	go test -race -coverprofile=coverage.txt -covermode=atomic github.com/ONSdigital/rm-survey-service/models
 
+# Run integration and unit tests with the service running in docker.
+integration-test: docker
+	docker-compose -f compose-integration-tests.yml down
+	docker-compose -f compose-integration-tests.yml up -d
+	./wait_for_startup_integration_tests.sh ||\
+	(docker-compose -f compose-integration-tests.yml down && exit 1)
+	go test --tags=integration -race -coverprofile=coverage.txt -covermode=atomic github.com/ONSdigital/rm-survey-service/models ||\
+	(docker-compose -f compose-integration-tests.yml down && exit 1)
+	docker-compose -f compose-integration-tests.yml down
+
 # Remove the build directory tree.
 clean:
 	if [ -d $(BUILD) ]; then rm -r $(BUILD); fi;

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ test:
 	go test -race -coverprofile=coverage.txt -covermode=atomic github.com/ONSdigital/rm-survey-service/models
 
 # Run integration and unit tests with the service running in docker.
+# Builds a docker image, starts it up with a postgres container, waits for a successful response from the survey service
+# /info endpoint, then runs unit tests and integration tests against the services in docker.
 integration-test: docker
 	docker-compose -f compose-integration-tests.yml down
 	docker-compose -f compose-integration-tests.yml up -d

--- a/README.md
+++ b/README.md
@@ -58,13 +58,18 @@ docker-compose down
 ```
 
 ## Testing
-To follow once I've worked out how to write unit tests in Go :-)
-
-Run the tests using:
+Run the unit tests using:
 
 ```
 make test
 ```
+
+To run the integration tests using `make` run:
+```bash
+make integration-test
+```
+
+This will build a docker image from source and run the container then run all tests including integration tests.
 
 ## Deployment
 To deploy to Cloud Foundry, run one of the targets below depending on the Cloud Foundry space you wish to push to:

--- a/compose-integration-tests.yml
+++ b/compose-integration-tests.yml
@@ -1,0 +1,21 @@
+database:
+  container_name: postgres-survey-it
+  image: postgres:9.6-alpine
+  ports:
+   - "15432:5432"
+  environment:
+  - POSTGRES_DB=postgres
+  - POSTGRES_USER=postgres
+  - POSTGRES_PASSWORD=password
+
+survey:
+  container_name: surveysvc-it
+  image: sdcplatform/surveysvc
+  ports:
+   - "9090:8080"
+  links:
+   - database
+  environment:
+  - DATABASE_URL=postgres://postgres:password@postgres-survey-it:5432/postgres?sslmode=disable
+  - security_user_name=admin
+  - security_user_password=secret

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	r.HandleFunc("/surveys/ref/{ref}", use(api.GetSurveyByReference, basicAuth)).Methods("GET")
 	r.HandleFunc("/surveys/{surveyId}/classifiertypeselectors", use(api.AllClassifierTypeSelectors, basicAuth)).Methods("GET")
 	r.HandleFunc("/surveys/{surveyId}/classifiertypeselectors/{classifierTypeSelectorId}", use(api.GetClassifierTypeSelectorByID, basicAuth)).Methods("GET")
+	r.HandleFunc("/surveys/{surveyId}/classifiers", use(api.PostSurveyClassifiers, basicAuth)).Methods("POST")
 	http.Handle("/", r)
 
 	srv := &http.Server{

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -23,8 +23,8 @@ type ClassifierTypeSelectorSummary struct {
 // ClassifierTypeSelector represents the detail of a classifier type selector.
 type ClassifierTypeSelector struct {
 	ID              string   `json:"id"`
-	Name            string   `json:"name" validate:"required"`
-	ClassifierTypes []string `json:"classifierTypes"`
+	Name            string   `json:"name" validate:"required,min=1,max=50,no-spaces"`
+	ClassifierTypes []string `json:"classifierTypes" validate:"required,min=1,dive,min=1,max=50,no-spaces"`
 }
 
 // Survey represents the details of a survey.
@@ -372,6 +372,11 @@ func (api *API) PostSurveyClassifiers(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, &postData)
 	if err != nil {
 		http.Error(w, "Error unmarshalling JSON", http.StatusBadRequest)
+		return
+	}
+	err = api.Validator.Struct(postData)
+	if err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -330,7 +330,6 @@ func (api *API) PostSurveyClassifiers(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Error creating classifier type selector for survey '"+surveyID+"' - "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-
 	var postData []ClassifierTypeSelector
 	err = json.Unmarshal(body, &postData)
 	if err != nil {

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -347,7 +347,7 @@ func (api *API) PostSurveyClassifiers(w http.ResponseWriter, r *http.Request) {
 
 	for _, classifierTypeSelector := range postData {
 
-		typeSelectorRows, err := api.GetClassifierTypeSelectorByIDStmt.Query(surveyID)
+		typeSelectorRows, err := api.GetClassifierTypeSelectorStmt.Query(surveyID)
 		if err != nil {
 			log.Fatal(err)
 			http.Error(w, "Error creating classifier type selector for survey '"+surveyID+"' - "+err.Error(), http.StatusInternalServerError)

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -56,6 +56,7 @@ type API struct {
 	GetSurveyRefStmt                  *sql.Stmt
 	PutSurveyDetailsBySurveyRefStmt   *sql.Stmt
 	CreateSurveyStmt                  *sql.Stmt
+	CreateSurveyClassifier            *sql.Stmt
 	GetLegalBasesStmt                 *sql.Stmt
 	GetLegalBasisFromLongNameStmt     *sql.Stmt
 	GetLegalBasisFromRefStmt          *sql.Stmt
@@ -135,6 +136,11 @@ func NewAPI(db *sql.DB) (*API, error) {
 		return nil, err
 	}
 
+	createSurveyClassifier, err := createStmt(sqlStatement, db) //TODO SQL statement
+	if err != nil {
+		return nil, err
+	}
+
 	validator := createValidator()
 
 	return &API{
@@ -148,6 +154,7 @@ func NewAPI(db *sql.DB) (*API, error) {
 		GetSurveyRefStmt:                  getSurveyRefStmt,
 		PutSurveyDetailsBySurveyRefStmt:   putSurveyDetailsBySurveyRefStmt,
 		CreateSurveyStmt:                  createSurvey,
+		CreateSurveyClassifier:            createSurveyClassifier,
 		GetLegalBasesStmt:                 getLegalBases,
 		GetLegalBasisFromLongNameStmt:     getLegalBasisFromLongName,
 		GetLegalBasisFromRefStmt:          getLegalBasisFromRef,
@@ -274,6 +281,11 @@ func (api *API) PostSurveyDetails(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Survey with ID %v already exists", postData.Reference), http.StatusConflict)
 		return
 	}
+}
+
+// PostSurveyClassifiers endpont handler - creates a new survey classifier
+func (api *API) PostSurveyClassifiers(w http.ResponseWriter, r *http.Request) {
+	// TODO create survey classifiers
 }
 
 // PutSurveyDetails endpoint handler changes a survey short name using the survey reference

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -896,18 +896,18 @@ func rollBack(tx *sql.Tx) {
 	}
 }
 
-// Log and message and an error and send a 500 HTTP response
-func logErrorAndRespond500(w http.ResponseWriter, logMessage string, err error) {
+// Log and message and an error and send an HTTP response
+func logErrorAndRespond(w http.ResponseWriter, logMessage string, status int, err error) {
 	logError(logMessage, err)
-	http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	http.Error(w, "Internal Server Error", status)
 }
 
-// Writes a 404 error response with a message
-func write404Response(w http.ResponseWriter, message string) {
-	response := NewRESTError("404", message)
+// Writes a NewRESTError and sends an HTTP response
+func writeRestErrorResponse(w http.ResponseWriter, message string, status int) {
+	response := NewRESTError(strconv.Itoa(status), message)
 	data, err := json.Marshal(response)
 	if err != nil {
-		logErrorAndRespond500(w, "Error marshalling NewRestError JSON", err)
+		logErrorAndRespond(w, "Error marshalling NewRestError JSON", http.StatusInternalServerError, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")

--- a/models/surveys_integration_test.go
+++ b/models/surveys_integration_test.go
@@ -3,14 +3,13 @@
 package models
 
 import (
-	"testing"
-	. "github.com/smartystreets/goconvey/convey"
 	"bytes"
-	"net/http"
 	"encoding/base64"
 	"encoding/json"
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"testing"
 )
-
 
 func createBasicAuth(username, password string) string {
 	auth := username + ":" + password
@@ -44,14 +43,14 @@ func TestAPI_PostSurveyClassifiers(t *testing.T) {
 			Name:            "TEST_SELECTOR_TYPE1",
 			ClassifierTypes: []string{"TEST1", "TEST2"},
 		}
-		classifiers := []ClassifierTypeSelector{classifier}
 
 		// Create HTTP request to post the classifier as JSON
-		postData, err := json.Marshal(classifiers)
+		postData, err := json.Marshal(classifier)
 		So(err, ShouldBeNil)
 		request, err := http.NewRequest("POST", "http://localhost:9090/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87/classifiers", bytes.NewReader(postData))
 		So(err, ShouldBeNil)
-		request.Header.Add("Authorization", createBasicAuth("admin", "secret"))
+		apiAuth := createBasicAuth("admin", "secret")
+		request.Header.Add("Authorization", apiAuth)
 		request.Header.Add("Content-Type", "application/json")
 
 		// Post the classifier and assert success 201 is the response status
@@ -61,14 +60,14 @@ func TestAPI_PostSurveyClassifiers(t *testing.T) {
 		So(response.StatusCode, ShouldEqual, http.StatusCreated)
 
 		// Decode and parse the response body to get the ID
-		var setupResponseClassifiers []ClassifierTypeSelector
+		var setupResponseClassifier ClassifierTypeSelector
 		defer response.Body.Close()
-		json.NewDecoder(response.Body).Decode(&setupResponseClassifiers)
+		json.NewDecoder(response.Body).Decode(&setupResponseClassifier)
 
 		// Use the ID to get the classifier we posted by a GET request
-		getClassifier, err := http.NewRequest("GET", "http://localhost:9090/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87/classifiertypeselectors/" + setupResponseClassifiers[0].ID, nil)
+		getClassifier, err := http.NewRequest("GET", "http://localhost:9090/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87/classifiertypeselectors/"+setupResponseClassifier.ID, nil)
 		So(err, ShouldBeNil)
-		getClassifier.Header.Add("Authorization", createBasicAuth("admin", "secret"))
+		getClassifier.Header.Add("Authorization", apiAuth)
 		getResponseClassifiers, err := client.Do(getClassifier)
 		So(err, ShouldBeNil)
 		So(getResponseClassifiers.StatusCode, ShouldEqual, http.StatusOK)

--- a/models/surveys_integration_test.go
+++ b/models/surveys_integration_test.go
@@ -1,0 +1,86 @@
+// +build integration
+
+package models
+
+import (
+	"testing"
+	. "github.com/smartystreets/goconvey/convey"
+	"bytes"
+	"net/http"
+	"encoding/base64"
+	"encoding/json"
+)
+
+
+func createBasicAuth(username, password string) string {
+	auth := username + ":" + password
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+// Assumes the service is running on localhost, port 9090
+func TestAPI_Info(t *testing.T) {
+	Convey("Can post new survey classifiers", t, func() {
+
+		// Given
+		request, err := http.NewRequest("GET", "http://localhost:9090/info", nil)
+		So(err, ShouldBeNil)
+		client := http.Client{}
+
+		// When
+		response, err := client.Do(request)
+		So(err, ShouldBeNil)
+
+		// Then
+		So(response.StatusCode, ShouldEqual, http.StatusOK)
+	})
+}
+
+// Assumes the service is running on localhost, port 9090
+func TestAPI_PostSurveyClassifiers(t *testing.T) {
+	Convey("Can post new survey classifiers", t, func() {
+
+		// Create a classifier made of a classifier type selector containing it's classifier types
+		classifier := ClassifierTypeSelector{
+			Name:            "TEST_SELECTOR_TYPE1",
+			ClassifierTypes: []string{"TEST1", "TEST2"},
+		}
+		classifiers := []ClassifierTypeSelector{classifier}
+
+		// Create HTTP request to post the classifer as JSON
+		postData, err := json.Marshal(classifiers)
+		So(err, ShouldBeNil)
+		request, err := http.NewRequest("POST", "http://localhost:9090/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87/classifiers", bytes.NewReader(postData))
+		So(err, ShouldBeNil)
+		request.Header.Add("Authorization", createBasicAuth("admin", "secret"))
+		request.Header.Add("Content-Type", "application/json")
+
+		// Post the classifier and assert success 201 is the response status
+		client := http.Client{}
+		response, err := client.Do(request)
+		So(err, ShouldBeNil)
+		So(response.StatusCode, ShouldEqual, http.StatusCreated)
+
+		// Decode and parse the response body to get the ID
+		var setupResponseClassifiers []ClassifierTypeSelector
+		defer response.Body.Close()
+		json.NewDecoder(response.Body).Decode(&setupResponseClassifiers)
+
+		// Use the ID to get the classifier we posted by a GET request
+		getClassifier, err := http.NewRequest("GET", "http://localhost:9090/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87/classifiertypeselectors/" + setupResponseClassifiers[0].ID, nil)
+		So(err, ShouldBeNil)
+		getClassifier.Header.Add("Authorization", createBasicAuth("admin", "secret"))
+		getResponseClassifiers, err := client.Do(getClassifier)
+		So(err, ShouldBeNil)
+		So(getResponseClassifiers.StatusCode, ShouldEqual, http.StatusOK)
+
+		// Assert that the classifier returned by the GET request is the same as we originally posted
+		var retrievedClassifier ClassifierTypeSelector
+		defer getResponseClassifiers.Body.Close()
+		err = json.NewDecoder(getResponseClassifiers.Body).Decode(&retrievedClassifier)
+		So(err, ShouldBeNil)
+		So(retrievedClassifier.Name, ShouldEqual, classifier.Name)
+		So(retrievedClassifier.ClassifierTypes, ShouldContain, classifier.ClassifierTypes[0])
+		So(retrievedClassifier.ClassifierTypes, ShouldContain, classifier.ClassifierTypes[1])
+		So(retrievedClassifier.ClassifierTypes, ShouldHaveLength, 2)
+	})
+}

--- a/models/surveys_integration_test.go
+++ b/models/surveys_integration_test.go
@@ -46,7 +46,7 @@ func TestAPI_PostSurveyClassifiers(t *testing.T) {
 		}
 		classifiers := []ClassifierTypeSelector{classifier}
 
-		// Create HTTP request to post the classifer as JSON
+		// Create HTTP request to post the classifier as JSON
 		postData, err := json.Marshal(classifiers)
 		So(err, ShouldBeNil)
 		request, err := http.NewRequest("POST", "http://localhost:9090/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87/classifiers", bytes.NewReader(postData))

--- a/models/surveys_test.go
+++ b/models/surveys_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/DATA-DOG/go-sqlmock"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -886,8 +886,9 @@ func TestCreateNewSurveyClassifiers(t *testing.T) {
 		So(err, ShouldBeNil)
 		defer api.Close()
 		w := httptest.NewRecorder()
-		var data = []byte(`{"name": "test", "classifierTypes": ["TEST1"]}`)
-		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/cb8accda-6118-4d3b-85a3-149e28960c54/classifiers", bytes.NewBuffer(data))
+		var data = []byte(`[{"name": "test", "classifierTypes": ["TEST1"]}]`)
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(data))
+		r.Header.Set("Content-Type", "application/json")
 		So(err, ShouldBeNil)
 		api.PostSurveyClassifiers(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)

--- a/models/surveys_test.go
+++ b/models/surveys_test.go
@@ -981,6 +981,8 @@ func TestCreateNewSurveyClassifiersSurveyNotFound(t *testing.T) {
 
 func TestCreateNewSurveyClassifiersAlreadyExistsConflict(t *testing.T) {
 	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
 		db, mock, err := sqlmock.New()
 		So(err, ShouldBeNil)
 		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")

--- a/models/surveys_test.go
+++ b/models/surveys_test.go
@@ -960,6 +960,188 @@ func TestCreateNewSurveyClassifiersAlreadyExistsConflict(t *testing.T) {
 	})
 }
 
+func TestCreateNewSurveyClassifiersNoName(t *testing.T) {
+	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
+		db, mock, err := sqlmock.New()
+		So(err, ShouldBeNil)
+		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")
+		prepareMockStmts(mock)
+		mock.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+").ExpectQuery().WithArgs(sqlmock.AnyArg()).WillReturnRows(surveyPKRows)
+		var postData = []byte(`{"classifierTypes": ["TEST"]}`)
+
+		// When
+		api, err := NewAPI(db)
+		So(err, ShouldBeNil)
+		defer api.Close()
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(postData))
+		r.Header.Set("Content-Type", "application/json")
+		So(err, ShouldBeNil)
+		api.PostSurveyClassifiers(w, r)
+
+		// Then
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
+func TestCreateNewSurveyClassifiersEmptyName(t *testing.T) {
+	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
+		db, mock, err := sqlmock.New()
+		So(err, ShouldBeNil)
+		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")
+		prepareMockStmts(mock)
+		mock.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+").ExpectQuery().WithArgs(sqlmock.AnyArg()).WillReturnRows(surveyPKRows)
+		var postData = []byte(`{"name": "", "classifierTypes": ["TEST1"]}`)
+
+		// When
+		api, err := NewAPI(db)
+		So(err, ShouldBeNil)
+		defer api.Close()
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(postData))
+		r.Header.Set("Content-Type", "application/json")
+		So(err, ShouldBeNil)
+		api.PostSurveyClassifiers(w, r)
+
+		// Then
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
+func TestCreateNewSurveyClassifiersWhitespaceName(t *testing.T) {
+	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
+		db, mock, err := sqlmock.New()
+		So(err, ShouldBeNil)
+		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")
+		prepareMockStmts(mock)
+		mock.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+").ExpectQuery().WithArgs(sqlmock.AnyArg()).WillReturnRows(surveyPKRows)
+		var postData = []byte(`{"name": " ", "classifierTypes": ["TEST1"]}`)
+
+		// When
+		api, err := NewAPI(db)
+		So(err, ShouldBeNil)
+		defer api.Close()
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(postData))
+		r.Header.Set("Content-Type", "application/json")
+		So(err, ShouldBeNil)
+		api.PostSurveyClassifiers(w, r)
+
+		// Then
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
+func TestCreateNewSurveyClassifiersNoClassifierTypes(t *testing.T) {
+	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
+		db, mock, err := sqlmock.New()
+		So(err, ShouldBeNil)
+		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")
+		prepareMockStmts(mock)
+		mock.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+").ExpectQuery().WithArgs(sqlmock.AnyArg()).WillReturnRows(surveyPKRows)
+		var postData = []byte(`{"name": "test"}`)
+
+		// When
+		api, err := NewAPI(db)
+		So(err, ShouldBeNil)
+		defer api.Close()
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(postData))
+		r.Header.Set("Content-Type", "application/json")
+		So(err, ShouldBeNil)
+		api.PostSurveyClassifiers(w, r)
+
+		// Then
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
+func TestCreateNewSurveyClassifiersEmptyClassifierTypes(t *testing.T) {
+	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
+		db, mock, err := sqlmock.New()
+		So(err, ShouldBeNil)
+		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")
+		prepareMockStmts(mock)
+		mock.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+").ExpectQuery().WithArgs(sqlmock.AnyArg()).WillReturnRows(surveyPKRows)
+		var postData = []byte(`{"name": "test",  "classifierTypes": []}`)
+
+		// When
+		api, err := NewAPI(db)
+		So(err, ShouldBeNil)
+		defer api.Close()
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(postData))
+		r.Header.Set("Content-Type", "application/json")
+		So(err, ShouldBeNil)
+		api.PostSurveyClassifiers(w, r)
+
+		// Then
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
+func TestCreateNewSurveyClassifiersWhitespaceClassifierTypes(t *testing.T) {
+	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
+		db, mock, err := sqlmock.New()
+		So(err, ShouldBeNil)
+		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")
+		prepareMockStmts(mock)
+		mock.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+").ExpectQuery().WithArgs(sqlmock.AnyArg()).WillReturnRows(surveyPKRows)
+		var postData = []byte(`{"name": "test",  "classifierTypes": [" "]}`)
+
+		// When
+		api, err := NewAPI(db)
+		So(err, ShouldBeNil)
+		defer api.Close()
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(postData))
+		r.Header.Set("Content-Type", "application/json")
+		So(err, ShouldBeNil)
+		api.PostSurveyClassifiers(w, r)
+
+		// Then
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
+func TestCreateNewSurveyClassifiersEmptyStringClassifierTypes(t *testing.T) {
+	Convey("Create new survey classifier already exists", t, func() {
+
+		// Given
+		db, mock, err := sqlmock.New()
+		So(err, ShouldBeNil)
+		surveyPKRows := sqlmock.NewRows([]string{"surveypk"}).AddRow("1000")
+		prepareMockStmts(mock)
+		mock.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+").ExpectQuery().WithArgs(sqlmock.AnyArg()).WillReturnRows(surveyPKRows)
+		var postData = []byte(`{"name": "test",  "classifierTypes": [""]}`)
+
+		// When
+		api, err := NewAPI(db)
+		So(err, ShouldBeNil)
+		defer api.Close()
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("POST", "http://localhost:9090/surveys/test-survey-id/classifiers", bytes.NewBuffer(postData))
+		r.Header.Set("Content-Type", "application/json")
+		So(err, ShouldBeNil)
+		api.PostSurveyClassifiers(w, r)
+
+		// Then
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
 func TestCreateNewSurveyClassifiers500Error(t *testing.T) {
 	Convey("Create new survey classifier returns 500", t, func() {
 

--- a/models/surveys_test.go
+++ b/models/surveys_test.go
@@ -892,5 +892,7 @@ func prepareMockStmts(m sqlmock.Sqlmock) {
 	m.ExpectPrepare("INSERT INTO survey.survey \\( surveypk, id, surveyref, shortname, longname, legalbasis, surveytype \\) VALUES \\( .+\\)")
 	m.ExpectPrepare("SELECT ref, longname FROM survey.legalbasis")
 	m.ExpectPrepare("SELECT surveyref FROM survey.survey WHERE shortname = .+")
-
+	m.ExpectPrepare("INSERT INTO survey.classifiertypeselector \\( classifiertypeselectorpk, id, surveyfk, classifiertypeselector \\) VALUES \\( .+\\) RETURNING classifiertypeselectorpk as id")
+	m.ExpectPrepare("INSERT INTO survey.classifiertype \\( classifiertypepk, classifiertypeselectorfk, classifiertype \\) VALUES \\( .+\\)")
+	m.ExpectPrepare("SELECT surveypk FROM survey.survey WHERE id = .+")
 }

--- a/wait_for_startup_integration_tests.sh
+++ b/wait_for_startup_integration_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Hit the survey service endpoint and exit on success or time out after 20 unsuccessful attempts with 2 second interval
-for i in {1..20}; do
+for _ in {1..20}; do
     curl -f http://localhost:9090/info
     if [ $? -eq 0 ]
     then

--- a/wait_for_startup_integration_tests.sh
+++ b/wait_for_startup_integration_tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Hit the survey service endpoint and exit on success or time out after 20 unsuccessful attempts with 2 second interval
+for i in {1..20}; do
+    curl -f http://localhost:9090/info
+    if [ $? -eq 0 ]
+    then
+        exit 0
+    fi
+    sleep 2
+done
+echo "No successful response from survey service, timing out"
+exit 1


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For a survey to be usable it needs classifiers, this PR adds an endpoint to post classifiers to a given survey.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added `POST /surveys/{surveyId}/classifiers` endpoint
* Added unit tests for endpoint
* Added integration test for post classifiers and info endpoint
* Added make target to run the service in docker and run integration tests against it
* Updated API.md and README.md according to changes
* Changed .travis.yml to run integration tests instead of unit tests and docker as these are all run as part of the integration test target

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the tests are valid and cover the requirements.

Run `make integration-test` target to make sure it is spinning up the services, running the tests and tearing down what it runs appropriately.

Try inserting `So(false, ShouldBeTrue)` into an integration test to induce a failure then run `make integration-test` and observe the tests should fail, container teardown still happens and the target exits with an error code.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/cnqv2QuY/182-add-endpoint-in-survey-service-to-add-classifiers-8