### PR TITLE
As part of sample file changes, survey ref is now alphanumeric

### DIFF
--- a/models/surveys.go
+++ b/models/surveys.go
@@ -33,7 +33,7 @@ type Survey struct {
 	ID            string `json:"id"`
 	ShortName     string `json:"shortName" validate:"required,no-spaces,max=20"`
 	LongName      string `json:"longName" validate:"required,max=100"`
-	Reference     string `json:"surveyRef" validate:"required,numeric,max=20"`
+	Reference     string `json:"surveyRef" validate:"required,max=20"`
 	LegalBasis    string `json:"legalBasis"`
 	SurveyType    string `json:"surveyType"`
 	LegalBasisRef string `json:"legalBasisRef"`


### PR DESCRIPTION
# Motivation and Context
Survey ref needs to be alphanumeric in order to accommodate social sample file changes

# What has changed
Removed validator against reference

# How to test?
```
{
        "shortName": "ZIFDI",
        "longName": "Zephyr Inward Foreign Direct Investment Survey",
        "surveyRef": "A12",
        "legalBasis": "Statistics of Trade Act 1947",
        "surveyType": "Social"
}
```
Send this as part of the post request to http://localhost:8080/surveys - this creates a survey. This request should now accept an alphanumeric reference and return a response with the survey's details.

# Links
https://trello.com/c/3PK5xIDM/238-sample-file-changes-for-operational-test-8
