### PR TITLE
Bump version to 10.49.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Service version.
-VERSION = 10.48.4
+VERSION = 10.49.0
 
 # Cross-compilation values.
 ARCH=amd64


### PR DESCRIPTION
# Motivation and Context
Bump version to 10.49.0 in preparation for release to preprod.
