### PR TITLE
Execute the Survey service under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update\
      && rm -rf /var/lib/apt/lists/*
 EXPOSE 8080
 
-RUN groupadd -g 995 surveysvc && \
-    useradd -r -u 995 -g surveysvc surveysvc
+RUN groupadd --gid 995 surveysvc && \
+    useradd --create-home --system --uid 995 --gid surveysvc surveysvc
 USER surveysvc
 
 COPY build/linux-amd64/bin/main /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM ubuntu:18.04
 
 RUN apt-get update\
-     && apt-get install curl -y --no-install-recommends\
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 EXPOSE 8080
+
+RUN groupadd -g 995 surveysvc && \
+    useradd -r -u 995 -g surveysvc surveysvc
+USER surveysvc
 
 COPY build/linux-amd64/bin/main /usr/local/bin/
 


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

**IMPORTANT: Note that this change must be merged at the same time as [the pull request to update the Kubernetes manifests for this change](https://github.com/ONSdigital/census-rm-kubernetes/pull/29).**

# What has changed
The Dockerfile has been changed:

* cURL should not be installed as it increases the attack surface of the container
* Create a dedicated non-root user account for executing the Go code

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Go process running as the expected non-root user account

# Links
https://github.com/ONSdigital/census-rm-kubernetes/pull/29