### PR TITLE
Update version to 10.50.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Service version.
-VERSION = 10.49.0
+VERSION = 10.50.0
 
 # Cross-compilation values.
 ARCH=amd64


### PR DESCRIPTION
# Motivation and Context
Bumping the version number from 10.49.0 to 10.50.0 ready for the next release.
