### PR TITLE
add logging for GET calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,6 @@ make integration-test
 
 This will build a docker image from source and run the container then run all tests including integration tests.
 
-## Deployment
-To deploy to Cloud Foundry, run one of the targets below depending on the Cloud Foundry space you wish to push to:
-
-```
-make push-ci
-make push-demo
-make push-dev
-make push-int
-make push-test
-```
 
 ## Cleaning
 To clobber the `build` directory tree that's created when running `make`, run:

--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ make clean
 ```
 
 ## Copyright
-Copyright (C) 2017 Crown Copyright (Office for National Statistics)
+Copyright (C) 2017 - 2020 Crown Copyright (Office for National Statistics)

--- a/_infra/helm/survey/Chart.yaml
+++ b/_infra/helm/survey/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.10
+appVersion: 11.0.11

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -605,7 +605,7 @@ func (api *API) PutSurveyDetails(w http.ResponseWriter, r *http.Request) {
 //Info endpoint handler returns info like name, version, origin, commit, branch
 //and built
 func (api *API) Info(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting info", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting info", zap.String("url", r.URL.Path))
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(NewVersion()); err != nil {
@@ -615,7 +615,7 @@ func (api *API) Info(w http.ResponseWriter, r *http.Request) {
 
 // AllSurveys returns a list of all known surveys
 func (api *API) AllSurveys(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting AllSurveys", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting AllSurveys", zap.String("url", r.URL.Path))
 	var rows *sql.Rows
 	var err error
 	rows, err = api.AllSurveysStmt.Query()
@@ -629,7 +629,7 @@ func (api *API) AllSurveys(w http.ResponseWriter, r *http.Request) {
 
 // SurveysByType returns surveys of a particular type
 func (api *API) SurveysByType(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting SurveysByType", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting SurveysByType", zap.String("url", r.URL.Path))
 	var rows *sql.Rows
 	var err error
 	var surveyMap = map[string]string{
@@ -693,7 +693,7 @@ func parseSurveys(rows *sql.Rows, w http.ResponseWriter) {
 
 // AllLegalBases returns details of all legal bases
 func (api *API) AllLegalBases(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting AllLegalBases", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting AllLegalBases", zap.String("url", r.URL.Path))
 	rows, err := api.GetLegalBasesStmt.Query()
 
 	if err != nil {
@@ -734,7 +734,7 @@ func (api *API) AllLegalBases(w http.ResponseWriter, r *http.Request) {
 
 // GetSurvey returns the details of the survey identified by the string surveyID.
 func (api *API) GetSurvey(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting Survey", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting Survey", zap.String("url", r.URL.Path))
 	vars := mux.Vars(r)
 	id := vars["surveyId"]
 	survey := new(Survey)
@@ -774,7 +774,7 @@ func (api *API) GetSurvey(w http.ResponseWriter, r *http.Request) {
 
 // GetSurveyByShortName returns the details of the survey identified by the string shortName.
 func (api *API) GetSurveyByShortName(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting SurveyByShortName", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting SurveyByShortName", zap.String("url", r.URL.Path))
 	vars := mux.Vars(r)
 	id := vars["shortName"]
 
@@ -817,7 +817,7 @@ func (api *API) GetSurveyByShortName(w http.ResponseWriter, r *http.Request) {
 
 // GetSurveyByReference returns the details of the survey identified by the string ref.
 func (api *API) GetSurveyByReference(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting SurveyByReference", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting SurveyByReference", zap.String("url", r.URL.Path))
 	vars := mux.Vars(r)
 	id := vars["ref"]
 
@@ -861,7 +861,7 @@ func (api *API) AllClassifierTypeSelectors(w http.ResponseWriter, r *http.Reques
 	// We need to run a query first to check if the survey exists so an HTTP 404 can be correctly
 	// returned if it doesn't exist. Without this check an HTTP 204 is incorrectly returned for an
 	// invalid survey ID.
-	logger.Info("Getting AllClassifierTypeSelectors", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting AllClassifierTypeSelectors", zap.String("url", r.URL.Path))
 	vars := mux.Vars(r)
 	surveyID := vars["surveyId"]
 
@@ -930,7 +930,7 @@ func (api *API) AllClassifierTypeSelectors(w http.ResponseWriter, r *http.Reques
 // GetClassifierTypeSelectorByID returns the details of the classifier type selector for the survey identified by the string surveyID and
 // the classifier type selector identified by the string classifierTypeSelectorID.
 func (api *API) GetClassifierTypeSelectorByID(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting ClassifierTypeSelectorByID", zap.String("url", r.URL.RawQuery))
+	logger.Info("Getting ClassifierTypeSelectorByID", zap.String("url", r.URL.Path))
 	vars := mux.Vars(r)
 	for _, u := range []string{"classifierTypeSelectorId", "surveyId"} {
 		val, ok := vars[u]

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -605,6 +605,7 @@ func (api *API) PutSurveyDetails(w http.ResponseWriter, r *http.Request) {
 //Info endpoint handler returns info like name, version, origin, commit, branch
 //and built
 func (api *API) Info(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting info", zap.String("url", r.URL.RawQuery))
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(NewVersion()); err != nil {
@@ -614,6 +615,7 @@ func (api *API) Info(w http.ResponseWriter, r *http.Request) {
 
 // AllSurveys returns a list of all known surveys
 func (api *API) AllSurveys(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting AllSurveys", zap.String("url", r.URL.RawQuery))
 	var rows *sql.Rows
 	var err error
 	rows, err = api.AllSurveysStmt.Query()
@@ -627,6 +629,7 @@ func (api *API) AllSurveys(w http.ResponseWriter, r *http.Request) {
 
 // SurveysByType returns surveys of a particular type
 func (api *API) SurveysByType(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting SurveysByType", zap.String("url", r.URL.RawQuery))
 	var rows *sql.Rows
 	var err error
 	var surveyMap = map[string]string{
@@ -690,6 +693,7 @@ func parseSurveys(rows *sql.Rows, w http.ResponseWriter) {
 
 // AllLegalBases returns details of all legal bases
 func (api *API) AllLegalBases(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting AllLegalBases", zap.String("url", r.URL.RawQuery))
 	rows, err := api.GetLegalBasesStmt.Query()
 
 	if err != nil {
@@ -730,6 +734,7 @@ func (api *API) AllLegalBases(w http.ResponseWriter, r *http.Request) {
 
 // GetSurvey returns the details of the survey identified by the string surveyID.
 func (api *API) GetSurvey(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting Survey", zap.String("url", r.URL.RawQuery))
 	vars := mux.Vars(r)
 	id := vars["surveyId"]
 	survey := new(Survey)
@@ -769,6 +774,7 @@ func (api *API) GetSurvey(w http.ResponseWriter, r *http.Request) {
 
 // GetSurveyByShortName returns the details of the survey identified by the string shortName.
 func (api *API) GetSurveyByShortName(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting SurveyByShortName", zap.String("url", r.URL.RawQuery))
 	vars := mux.Vars(r)
 	id := vars["shortName"]
 
@@ -811,6 +817,7 @@ func (api *API) GetSurveyByShortName(w http.ResponseWriter, r *http.Request) {
 
 // GetSurveyByReference returns the details of the survey identified by the string ref.
 func (api *API) GetSurveyByReference(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting SurveyByReference", zap.String("url", r.URL.RawQuery))
 	vars := mux.Vars(r)
 	id := vars["ref"]
 
@@ -854,6 +861,7 @@ func (api *API) AllClassifierTypeSelectors(w http.ResponseWriter, r *http.Reques
 	// We need to run a query first to check if the survey exists so an HTTP 404 can be correctly
 	// returned if it doesn't exist. Without this check an HTTP 204 is incorrectly returned for an
 	// invalid survey ID.
+	logger.Info("Getting AllClassifierTypeSelectors", zap.String("url", r.URL.RawQuery))
 	vars := mux.Vars(r)
 	surveyID := vars["surveyId"]
 
@@ -922,6 +930,7 @@ func (api *API) AllClassifierTypeSelectors(w http.ResponseWriter, r *http.Reques
 // GetClassifierTypeSelectorByID returns the details of the classifier type selector for the survey identified by the string surveyID and
 // the classifier type selector identified by the string classifierTypeSelectorID.
 func (api *API) GetClassifierTypeSelectorByID(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Getting ClassifierTypeSelectorByID", zap.String("url", r.URL.RawQuery))
 	vars := mux.Vars(r)
 	for _, u := range []string{"classifierTypeSelectorId", "surveyId"} {
 		val, ok := vars[u]


### PR DESCRIPTION
# Motivation and Context
The survey service logs things on startup, on creation of things and errors  but doesn't log anything when it is having GET calls on it.
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Added one-liner info logging to nine GETs for /info, /surveys and /legalbases
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
- deploy to sandbox
- run acceptance tests
- watch pod logs for "Getting..." messages, with URLs.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
- https://trello.com/c/cMvKac6p
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
