### PR TITLE
add classifier for collection exercise id for SEFT surveys

### DIFF
--- a/_infra/helm/survey/Chart.yaml
+++ b/_infra/helm/survey/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.0.33
+version: 11.0.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.33
+appVersion: 11.0.34

--- a/db-migrations/13_add_classifiertypes_collection_exercise_seft_surveys.down.sql
+++ b/db-migrations/13_add_classifiertypes_collection_exercise_seft_surveys.down.sql
@@ -1,0 +1,12 @@
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 52;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 53;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 54;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 55;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 56;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 57;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 58;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 59;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 60;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 61;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 62;
+DELETE FROM survey.classifiertype WHERE classifiertypepk = 63;

--- a/db-migrations/13_add_classifiertypes_collection_exercise_seft_surveys.up.sql
+++ b/db-migrations/13_add_classifiertypes_collection_exercise_seft_surveys.up.sql
@@ -1,0 +1,12 @@
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (52, 3, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (53, 4, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (54, 5, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (55, 6, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (56, 7, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (57, 8, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (58, 9, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (59, 11, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (60, 13, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (61, 14, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (62, 15, 'COLLECTION_EXERCISE');
+INSERT INTO survey.classifiertype (classifiertypepk, classifiertypeselectorfk, classifiertype) VALUES (63, 16, 'COLLECTION_EXERCISE');


### PR DESCRIPTION
# What and why?
add classifier for collection exercise id for SEFT surveys to fix a bug. this should allow us to find a singular exercise during lookup and not have to use the most recent. 

# How to test?

# Trello
https://trello.com/c/zDZwHxJ6/960-bug-fix-collection-instrument-most-recent-instrument-for-seft