### PR TITLE
Remove logging from /info

### DIFF
--- a/_infra/helm/survey/Chart.yaml
+++ b/_infra/helm/survey/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.0.34
+version: 11.0.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.34
+appVersion: 11.0.35

--- a/models/surveys.go
+++ b/models/surveys.go
@@ -618,7 +618,6 @@ func (api *API) PutSurveyDetails(w http.ResponseWriter, r *http.Request) {
 //Info endpoint handler returns info like name, version, origin, commit, branch
 //and built
 func (api *API) Info(w http.ResponseWriter, r *http.Request) {
-	logger.Info("Getting info", zap.String("url", r.URL.Path))
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(NewVersion()); err != nil {


### PR DESCRIPTION
# What and why?
This causes a ton of noise and isnt actually useful

# How to test?

# Trello
https://trello.com/c/4lFWM4ub/1192-remove-logging-on-info-endpoint-in-rm-survey-service