### PR TITLE
RAS-1238 Update to docker compose from docker-compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,23 @@ jobs:
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+      - name: Import BOT GPG key
+        run: echo $BOT_GPG_KEY | base64 --decode | gpg --batch --import
+        env:
+          BOT_GPG_KEY: ${{ secrets.BOT_GPG_KEY }}
+      - name: Prepare gpg CLI signing step
+        run: |
+          rm -rf /tmp/gpg.sh
+          echo '#!/bin/bash' >> /tmp/gpg.sh
+          echo 'gpg --batch --pinentry-mode=loopback --passphrase $BOT_GPG_KEY_PASSPHRASE $@' >> /tmp/gpg.sh
+          chmod +x /tmp/gpg.sh
+      - name: Setup git
+        run: |
+          git config commit.gpgsign true
+          git config user.signingkey "${{ secrets.BOT_GPG_KEY_ID }}"
+          git config gpg.program /tmp/gpg.sh
+          git config user.name "${{ secrets.BOT_USERNAME }}"
+          git config user.email "${{ secrets.BOT_EMAIL }}"
       - name: update versions
         if: github.ref != 'refs/heads/main'
         env:

--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,13 @@ test:
 # Builds a docker image, starts it up with a postgres container, waits for a successful response from the survey service
 # /info endpoint, then runs unit tests and integration tests against the services in docker.
 integration-test: docker
-	docker-compose -f compose-integration-tests.yml down
-	docker-compose -f compose-integration-tests.yml up -d
+	docker compose -f compose-integration-tests.yml down
+	docker compose -f compose-integration-tests.yml up -d
 	./wait_for_startup_integration_tests.sh ||\
-	(docker-compose -f compose-integration-tests.yml down && exit 1)
+	(docker compose -f compose-integration-tests.yml down && exit 1)
 	go test --tags=integration -race -coverprofile=coverage.txt -covermode=atomic github.com/ONSdigital/rm-survey-service/models ||\
-	(docker-compose -f compose-integration-tests.yml down && exit 1)
-	docker-compose -f compose-integration-tests.yml down
+	(docker compose -f compose-integration-tests.yml down && exit 1)
+	docker compose -f compose-integration-tests.yml down
 
 # Remove the build directory tree.
 clean:

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Once the app is running you should call the app with blank http auth values. Thi
 To start Docker containers for both PostgreSQL and the Survey service, run:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 To stop and remove the two Docker containers, run:
 
 ```
-docker-compose down
+docker compose down
 ```
 
 ## Testing

--- a/_infra/helm/survey/Chart.yaml
+++ b/_infra/helm/survey/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.0.57
+version: 11.0.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.57
+appVersion: 11.0.58

--- a/compose-integration-tests.yml
+++ b/compose-integration-tests.yml
@@ -1,21 +1,22 @@
-database:
-  container_name: postgres-survey-it
-  image: postgres:9.6-alpine
-  ports:
-   - "15432:5432"
-  environment:
-  - POSTGRES_DB=postgres
-  - POSTGRES_USER=postgres
-  - POSTGRES_PASSWORD=password
+services:
+  database:
+    container_name: postgres-survey-it
+    image: postgres:9.6-alpine
+    ports:
+     - "15432:5432"
+    environment:
+    - POSTGRES_DB=postgres
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=password
 
-survey:
-  container_name: surveysvc-it
-  image: sdcplatform/surveysvc
-  ports:
-   - "9090:8080"
-  links:
-   - database
-  environment:
-  - DATABASE_URL=postgres://postgres:password@postgres-survey-it:5432/postgres?sslmode=disable
-  - security_user_name=admin
-  - security_user_password=secret
+  survey:
+    container_name: surveysvc-it
+    image: sdcplatform/surveysvc
+    ports:
+     - "9090:8080"
+    links:
+     - database
+    environment:
+    - DATABASE_URL=postgres://postgres:password@postgres-survey-it:5432/postgres?sslmode=disable
+    - security_user_name=admin
+    - security_user_password=secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,22 @@
-database:
-  container_name: postgres
-  image: postgres:9.6-alpine
-  ports:
-   - "5432:5432"
-  environment:
-  - POSTGRES_DB=postgres
-  - POSTGRES_USER=postgres
-  - POSTGRES_PASSWORD=password
+services:
+  database:
+    container_name: postgres
+    image: postgres:9.6-alpine
+    ports:
+     - "5432:5432"
+    environment:
+    - POSTGRES_DB=postgres
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=password
 
-survey:
-  container_name: surveysvc
-  image: eu.gcr.io/ons-rasrmbs-management/survey
-  ports:
-   - "8080:8080"
-  links:
-   - database
-  environment:
-  - DATABASE_URL=postgres://postgres:password@database/postgres?sslmode=disable
-  - security_user_name=admin
-  - security_user_password=secret
+  survey:
+    container_name: surveysvc
+    image: eu.gcr.io/ons-rasrmbs-management/survey
+    ports:
+     - "8080:8080"
+    links:
+     - database
+    environment:
+    - DATABASE_URL=postgres://postgres:password@database/postgres?sslmode=disable
+    - security_user_name=admin
+    - security_user_password=secret


### PR DESCRIPTION
# What and why?
Updating references to the now removed `docker-compose` in favour of `docker compose`
# How to test?
Run the `make integration-tests` command, make sure that the `docker-compose.yml` files now work, and make sure that the tests run properly in the GHA build
# Jira
[RAS-1238](https://jira.ons.gov.uk/browse/RAS-1238)