### PR TITLE
RAS-2044 WIF and Cloud SQL Proxy Migration

### DIFF
--- a/_infra/helm/survey/Chart.yaml
+++ b/_infra/helm/survey/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.0.70
+version: 11.0.71
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.70
+appVersion: 11.0.71

--- a/_infra/helm/survey/templates/deployment.yaml
+++ b/_infra/helm/survey/templates/deployment.yaml
@@ -21,16 +21,11 @@ spec:
         helmVersion: {{ .Chart.Version }}
         env: {{ .Values.env }}
     spec:
-      {{- if .Values.database.sqlProxyEnabled }}
-      volumes:
-        - name: cloudsql-instance-credentials
-          secret:
-            secretName: cloudsql-proxy-credentials
-            defaultMode: 0444
-            items:
-            - key: "credentials.json"
-              path: "credentials.json"
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      imagePullSecrets:
+          {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      nodeSelector:
+        iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         {{- if .Values.database.sqlProxyEnabled }}
         - name: cloudsql-proxy
@@ -38,16 +33,11 @@ spec:
           command: ["/cloud_sql_proxy",
                     "-instances=$(SQL_INSTANCE_NAME)=tcp:$(DB_PORT)",
                     "-ip_address_types=PRIVATE",
-                    "-credential_file=/secrets/cloudsql/credentials.json",
                     "-term_timeout=30s",
                     "-verbose=false"]
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false
-          volumeMounts:
-            - name: cloudsql-instance-credentials
-              mountPath: /secrets/cloudsql
-              readOnly: true
           env:
           - name: SQL_INSTANCE_NAME
             valueFrom:

--- a/_infra/helm/survey/values.yaml
+++ b/_infra/helm/survey/values.yaml
@@ -1,5 +1,12 @@
 env: minikube
 namespace: minikube
+
+serviceAccount:
+  name: ras-rm-k8s-services
+
+imagePullSecrets:
+  - name: gar-secret
+
 image:
   devRepo: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   name: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images


### PR DESCRIPTION
# What and why?
Migrated to use WIF and removes the cloud sql proxy credentials. 
# How to test?
Deploy through spinnaker using the helm chart pipeline. Test survey working as expected with the WIF SA.
# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-2045